### PR TITLE
Use different access token when publishing benchmark results

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
       - master
+      - fixactions
 name: Build&Benchmark
 jobs:
   buildBenchmark:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -21,4 +21,5 @@ jobs:
       - name: Upload updated results
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: docker run -e GITHUB_TOKEN --rm stestagg/cavro -c 'make upload_benchmark_docker'
+          UPLOAD_TOKEN: ${{ secrets.UPLOAD_TOKEN }}
+        run: docker run -e GITHUB_TOKEN -e UPLOAD_TOKEN --rm stestagg/cavro -c 'make upload_benchmark_docker'

--- a/benchmark/update_docs.py
+++ b/benchmark/update_docs.py
@@ -108,7 +108,7 @@ def save_docs(html):
 
 def upload_docs(html):
     print("Uploading html")
-    g = github.Github(os.environ['GITHUB_TOKEN'])
+    g = github.Github(os.environ['UPLOAD_TOKEN'])
     g.FIX_REPO_GET_GIT_REF = False
     gh_repo = g.get_user('stestagg').get_repo('cavro')
 
@@ -147,7 +147,7 @@ def main():
     formatted = format_results(results)
     html = render_docs(formatted, latest_commit)
     save_docs(html)
-    if 'GITHUB_TOKEN' in os.environ:
+    if 'UPLOAD_TOKEN' in os.environ:
         upload_docs(html)
     else:
         save_docs(html)


### PR DESCRIPTION
Github don't allow the token used by the actions runner to perform many operations.

One of these is committing to a branch and deploying pages.

This change uses a different access token for those actions