### PR TITLE
Benchmark include hash

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -53,7 +53,7 @@ jobs:
             const content = fs.readFileSync('perf_results.json').toString('base64');
             const message = 'Update perf_results.json from GitHub Actions';
 
-            await github.rest.repos.createOrUpdateFileContents({  
+            await github.rest.repos.createOrUpdateFileContents({
               owner, repo, path, branch, sha, content, message
             })
         env:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Run Benchmark
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: PYTHONPATH=. python3 benchmark/main.py --output perf_results.json
+        run: PYTHONPATH=. python3 benchmark/main.py --output perf_results.json -h ${{ github.sha }}
 
       - uses: actions/github-script@v6
         with:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -43,7 +43,6 @@ jobs:
       - uses: actions/github-script@v6
         with:
           script: |
-            import { readFileSync } from 'node:fs';
             const branch = 'perf';
             const ref = branch;
             const path = 'perf_results.json';
@@ -54,7 +53,7 @@ jobs:
             const content = fs.readFileSync('perf_results.json').toString('base64');
             const message = 'Update perf_results.json from GitHub Actions';
 
-            github.rest.repos.createOrUpdateFileContents({  
+            await github.rest.repos.createOrUpdateFileContents({  
               owner, repo, path, branch, sha, content, message
             })
         env:

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -2,7 +2,7 @@ name: TestPR
 
 on:
   pull_request:
-    
+
 jobs:
   buildTest:
     name: Build, Test & Benchmark code
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      
+
       - uses: actions/setup-python@v3
 
       - name: Install cavro
@@ -32,7 +32,7 @@ jobs:
         name: Run Benchmark
         run: |
           PYTHONPATH=. python3 benchmark/main.py -s outputs/benchmark_output.txt
-      
+
       - name: Write PR number
         run: echo "${{ github.event.number }}" > outputs/pr.txt
 

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -31,7 +31,7 @@ jobs:
       - id: benchmark
         name: Run Benchmark
         run: |
-          PYTHONPATH=. python3 benchmark/main.py -s outputs/benchmark_output.txt -h ${{ github.sha }}
+          PYTHONPATH=. python3 benchmark/main.py -s outputs/benchmark_output.txt
       
       - name: Write PR number
         run: echo "${{ github.event.number }}" > outputs/pr.txt

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -31,7 +31,7 @@ jobs:
       - id: benchmark
         name: Run Benchmark
         run: |
-          PYTHONPATH=. python3 benchmark/main.py -s outputs/benchmark_output.txt
+          PYTHONPATH=. python3 benchmark/main.py -s outputs/benchmark_output.txt -h ${{ github.sha }}
       
       - name: Write PR number
         run: echo "${{ github.event.number }}" > outputs/pr.txt

--- a/benchmark/main.py
+++ b/benchmark/main.py
@@ -77,6 +77,7 @@ def run_benchmark(test_classes, methods, num, mul, fail, prof):
 
 def print_results(results):
     print("Benchmark results")
+    print(f"Commit Hash: {results.get('hash')}")
     print(f'Library Versions:')
     for lib, version in results['versions'].items():
         print(f"\t{lib}: \x1b[31;1m{version}\x1b[0m")
@@ -175,7 +176,8 @@ if HAVE_AVRO_COMPAT:
 @click.option('--prof', help="Profile with specified sort", default=None)
 @click.option('--output', '-o', help="Write results to file", type=click.Path(dir_okay=False, writable=True, path_type=Path), default=None)
 @click.option('--summary', '-s', help="Write text summary to file", type=click.Path(dir_okay=False, writable=True, path_type=Path), default=None)
-def main(method, test, num, mul, fail, prof, output, summary):
+@click.option('--hash', '-h', help="Hash value to include in results", default=None)
+def main(method, test, num, mul, fail, prof, output, summary, hash):
     if test:
         test_classes = [t for t in ALL_TEST_CLASSES if t.NAME in test]
     else:
@@ -192,6 +194,8 @@ def main(method, test, num, mul, fail, prof, output, summary):
 
     all_results = run_benchmark(test_classes, method, num, mul, fail, prof)
     out = wrap_results(all_results)
+    if hash:
+        out['hash'] = hash
 
     if output is not None:
         if output.exists():


### PR DESCRIPTION
When benchmark is run on main, we need to capture the results for the historical display.
These results need to have a hash so we know what commit they ran against.